### PR TITLE
apfs: fix failed compilation due to idmap mount changes in v5.12

### DIFF
--- a/apfs.h
+++ b/apfs.h
@@ -636,18 +636,32 @@ extern int apfs_inode_by_name(struct inode *dir, const struct qstr *child,
 			      u64 *ino);
 extern int apfs_mkany(struct inode *dir, struct dentry *dentry,
 		      umode_t mode, dev_t rdev, const char *symname);
-extern int apfs_mknod(struct inode *dir, struct dentry *dentry,
-		      umode_t mode, dev_t rdev);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+extern int apfs_mknod(struct inode *dir, struct dentry *dentry, umode_t mode,
+		      dev_t rdev);
 extern int apfs_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode);
+extern int apfs_rename(struct inode *old_dir, struct dentry *old_dentry,
+		       struct inode *new_dir, struct dentry *new_dentry,
+		       unsigned int flags);
 extern int apfs_create(struct inode *dir, struct dentry *dentry, umode_t mode,
 		       bool excl);
+#else
+extern int apfs_mknod(struct user_namespace *mnt_userns, struct inode *dir,
+		      struct dentry *dentry, umode_t mode, dev_t rdev);
+extern int apfs_mkdir(struct user_namespace *mnt_userns, struct inode *dir,
+		      struct dentry *dentry, umode_t mode);
+extern int apfs_rename(struct user_namespace *mnt_userns, struct inode *old_dir,
+		       struct dentry *old_dentry, struct inode *new_dir,
+		       struct dentry *new_dentry, unsigned int flags);
+extern int apfs_create(struct user_namespace *mnt_userns, struct inode *dir,
+		       struct dentry *dentry, umode_t mode, bool excl);
+#endif
+
 extern int apfs_link(struct dentry *old_dentry, struct inode *dir,
 		     struct dentry *dentry);
 extern int apfs_unlink(struct inode *dir, struct dentry *dentry);
 extern int apfs_rmdir(struct inode *dir, struct dentry *dentry);
-extern int apfs_rename(struct inode *old_dir, struct dentry *old_dentry,
-		       struct inode *new_dir, struct dentry *new_dentry,
-		       unsigned int flags);
 extern int apfs_delete_orphan_link(struct inode *inode);
 extern int APFS_DELETE_ORPHAN_LINK_MAXOPS(void);
 
@@ -673,14 +687,27 @@ extern struct inode *apfs_new_inode(struct inode *dir, umode_t mode,
 extern int apfs_create_inode_rec(struct super_block *sb, struct inode *inode,
 				 struct dentry *dentry);
 extern int APFS_CREATE_INODE_REC_MAXOPS(void);
+
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
 extern int apfs_setattr(struct dentry *dentry, struct iattr *iattr);
+#else
+extern int apfs_setattr(struct user_namespace *mnt_userns,
+			struct dentry *dentry, struct iattr *iattr);
+#endif
+
 long apfs_dir_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
 long apfs_file_ioctl(struct file *file, unsigned int cmd, unsigned long arg);
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0) /* No statx yet... */
-extern int apfs_getattr(struct vfsmount *mnt, struct dentry *dentry, struct kstat *stat);
+extern int apfs_getattr(struct vfsmount *mnt, struct dentry *dentry,
+			struct kstat *stat);
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+extern int apfs_getattr(const struct path *path, struct kstat *stat,
+			u32 request_mask, unsigned int query_flags);
 #else
-extern int apfs_getattr(const struct path *path, struct kstat *stat, u32 request_mask, unsigned int query_flags);
+extern int apfs_getattr(struct user_namespace *mnt_userns,
+		const struct path *path, struct kstat *stat, u32 request_mask,
+		unsigned int query_flags);
 #endif
 
 extern int apfs_crypto_adj_refcnt(struct super_block *sb, u64 crypto_id, int delta);

--- a/namei.c
+++ b/namei.c
@@ -30,7 +30,13 @@ static struct dentry *apfs_lookup(struct inode *dir, struct dentry *dentry,
 	return d_splice_alias(inode, dentry);
 }
 
-static int apfs_symlink(struct inode *dir, struct dentry *dentry, const char *symname)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
+static int apfs_symlink(struct inode *dir, struct dentry *dentry,
+			const char *symname)
+#else
+static int apfs_symlink(struct user_namespace *mnt_userns, struct inode *dir,
+			struct dentry *dentry, const char *symname)
+#endif
 {
 	/* Symlink permissions don't mean anything and their value is fixed */
 	return apfs_mkany(dir, dentry, S_IFLNK | 0x1ed, 0 /* rdev */, symname);

--- a/xattr.c
+++ b/xattr.c
@@ -423,10 +423,16 @@ int APFS_XATTR_SET_MAXOPS(void)
 	return 1;
 }
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5, 12, 0)
 static int apfs_xattr_osx_set(const struct xattr_handler *handler,
-			      struct dentry *unused, struct inode *inode,
-			      const char *name, const void *value,
-			      size_t size, int flags)
+	      struct dentry *unused, struct inode *inode, const char *name,
+	      const void *value, size_t size, int flags)
+#else
+static int apfs_xattr_osx_set(const struct xattr_handler *handler,
+		  struct user_namespace *mnt_userns, struct dentry *unused,
+		  struct inode *inode, const char *name, const void *value,
+		  size_t size, int flags)
+#endif
 {
 	struct super_block *sb = inode->i_sb;
 	struct apfs_max_ops maxops;


### PR DESCRIPTION
Since kernel commit 549c7297717c ("fs: make helpers idmap mount aware")
extended the exisiting inode method to let filesystems be aware of
idmapped mounts, compiling apfs module with linux v5.12 failed:


make
make -C /lib/modules/5.12.0-custom/build M=/root/rw
make[1]: Entering directory '/root/linux'
  CC [M]  /root/linux-apfs-rw/dir.o
/root/linux-apfs-rw/dir.c:644:5: error: conflicting types for apfs_mknod
  644 | int apfs_mknod(struct inode *dir, struct dentry *dentry, umode_t mode, dev_t rdev)
      |     ^~~~~~~~~~
In file included from /root/linux-apfs-rw/dir.c:8:
/root/linux-apfs-rw/apfs.h:642:12: note: previous declaration of apfs_mknod was here
  642 | extern int apfs_mknod(struct user_namespace *mnt_userns, struct inode *dir,
      |            ^~~~~~~~~~
/root/linux-apfs-rw/dir.c:649:5: error: conflicting types for apfs_mkdir
  649 | int apfs_mkdir(struct inode *dir, struct dentry *dentry, umode_t mode)
      |     ^~~~~~~~~~
In file included from /root/linux-apfs-rw/dir.c:8:
/root/linux-apfs-rw/apfs.h:644:12: note: previous declaration of apfs_mkdir was here
  644 | extern int apfs_mkdir(struct user_namespace *mnt_userns, struct inode *dir,
      |            ^~~~~~~~~~
/root/linux-apfs-rw/dir.c:654:5: error: conflicting types for apfs_create
  654 | int apfs_create(struct inode *dir, struct dentry *dentry, umode_t mode,
      |     ^~~~~~~~~~~
In file included from /root/linux-apfs-rw/dir.c:8:
/root/linux-apfs-rw/apfs.h:649:12: note: previous declaration of apfs_create was here
  649 | extern int apfs_create(struct user_namespace *mnt_userns, struct inode *dir,
      |            ^~~~~~~~~~~
/root/linux-apfs-rw/dir.c:1197:5: error: conflicting types for apfs_rename
 1197 | int apfs_rename(struct inode *old_dir, struct dentry *old_dentry,
      |     ^~~~~~~~~~~
In file included from /root/linux-apfs-rw/dir.c:8:
/root/linux-apfs-rw/apfs.h:646:12: note: previous declaration of apfs_rename was here
  646 | extern int apfs_rename(struct user_namespace *mnt_userns, struct inode *old_dir,
      |            ^~~~~~~~~~~
make[2]: *** [scripts/Makefile.build:271: /root/linux-apfs-rw/dir.o] Error 1
make[1]: *** [Makefile:1851: /root/rw] Error 2
make[1]: Leaving directory '/root/linux'
make: *** [Makefile:14: default] Error 2


Although keeping forward and backward compatibilities is painful,
add awful preprocessors to let compilation pass.

Signed-off-by: Su Yue <l@damenly.su>