### PR TITLE
Fix module name in dkms.conf

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,7 +1,7 @@
 PACKAGE_NAME="linux-apfs-rw"
 PACKAGE_VERSION="0.2"
 
-BUILT_MODULE_NAME[0]="apfsrw"
+BUILT_MODULE_NAME[0]="apfs"
 DEST_MODULE_LOCATION[0]="/extra"
 
 AUTOINSTALL="yes"


### PR DESCRIPTION
Currently, the module name doesn't match what is built, so dkms fails.