### PR TITLE
Allow changing KERNEL_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@
 #
 
 KERNELRELEASE ?= $(shell uname -r)
+KERNEL_DIR    ?= /lib/modules/$(KERNELRELEASE)/build
 
 obj-m = apfs.o
 apfs-y := btree.o compress.o dir.o extents.o file.o inode.o key.o message.o \
@@ -11,6 +12,6 @@ apfs-y := btree.o compress.o dir.o extents.o file.o inode.o key.o message.o \
 	  unicode.o xattr.o xfield.o
 
 default:
-	make -C /lib/modules/$(KERNELRELEASE)/build M=$(shell pwd)
+	make -C $(KERNEL_DIR) M=$(shell pwd)
 clean:
-	make -C /lib/modules/$(KERNELRELEASE)/build M=$(shell pwd) clean
+	make -C $(KERNEL_DIR) M=$(shell pwd) clean


### PR DESCRIPTION
Allow building in a different directory.
This is useful on NixOS, where all software is stored under /nix.
As a nice side-effect, this change also reduces code duplication a little.

This is the same change as in https://github.com/linux-apfs/linux-apfs-oot/pull/8.