### PR TITLE
Use variable in Makefile for PWD instead of calling "shell pwd" directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@
 
 KERNELRELEASE ?= $(shell uname -r)
 KERNEL_DIR    ?= /lib/modules/$(KERNELRELEASE)/build
+PWD           := $(shell pwd)
 
 obj-m = apfs.o
 apfs-y := btree.o compress.o dir.o extents.o file.o inode.o key.o message.o \
@@ -12,6 +13,6 @@ apfs-y := btree.o compress.o dir.o extents.o file.o inode.o key.o message.o \
 	  unicode.o xattr.o xfield.o
 
 default:
-	make -C $(KERNEL_DIR) M=$(shell pwd)
+	make -C $(KERNEL_DIR) M=$(PWD)
 clean:
-	make -C $(KERNEL_DIR) M=$(shell pwd) clean
+	make -C $(KERNEL_DIR) M=$(PWD) clean


### PR DESCRIPTION
This reduces code duplication a tiny bit and makes it easier to change the value of PWD, for example to the value of the $PWD environment variable, instead of calling `shell pwd`, should the need arise in the future.

I think this also looks nicer.
My next PR will propose adding an `install:` target to the Makefile, which would add another `shell pwd`.
If you think the extra line for defining the variable is not worth it, feel free to simply reject this PR.

This is the same change as in https://github.com/linux-apfs/linux-apfs-oot/pull/9 but with a different commit message.