### PR TITLE
Add install target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,7 @@ apfs-y := btree.o compress.o dir.o extents.o file.o inode.o key.o message.o \
 
 default:
 	make -C $(KERNEL_DIR) M=$(PWD)
+install:
+	make -C $(KERNEL_DIR) M=$(PWD) modules_install
 clean:
 	make -C $(KERNEL_DIR) M=$(PWD) clean


### PR DESCRIPTION
I will use this to make packaging the kernel module on NixOS easier. Executing this target will automatically compress `apfs.ko` and put it into the correct directory, `$out/lib/modules/kernel-version-here/extra/` in the case of NixOS.
I have not tested this on any other Linux distro.