### PR TITLE
inode: remove apfs_noop_invalidatepage() stub

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -505,10 +505,6 @@ out_abort:
 	return err;
 }
 
-static void apfs_noop_invalidatepage(struct page *page, unsigned int offset, unsigned int length)
-{
-}
-
 /* bmap is not implemented to avoid issues with CoW on swapfiles */
 static const struct address_space_operations apfs_aops = {
 	.readpage	= apfs_readpage,
@@ -519,9 +515,6 @@ static const struct address_space_operations apfs_aops = {
 #endif
 	.write_begin	= apfs_write_begin,
 	.write_end	= apfs_write_end,
-
-	/* The intention is to keep bhs around until the transaction is over */
-	.invalidatepage	= apfs_noop_invalidatepage,
 };
 
 /**


### PR DESCRIPTION
And fix build for Linux-5.18.

Signed-off-by: Paolo Pisati <paolo.pisati@canonical.com>