### PR TITLE
fix: unable to install with dkms

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -1,6 +1,8 @@
 PACKAGE_NAME="linux-apfs-rw"
 PACKAGE_VERSION="0.2"
 
+MAKE[0]="make KERNELDIR=/lib/modules/${kernelver}/build"
+CLEAN="make clean"
 BUILT_MODULE_NAME[0]="apfs"
 DEST_MODULE_LOCATION[0]="/extra"
 


### PR DESCRIPTION
`
MAKE[0]="make KERNELDIR=/lib/modules/${kernelver}/build"
`
`
CLEAN="make clean"
`