### PR TITLE
Use linux/match64.h for u64 division

### DIFF
--- a/apfs.h
+++ b/apfs.h
@@ -6,6 +6,7 @@
 #ifndef _APFS_H
 #define _APFS_H
 
+#include <linux/math64.h>
 #include <linux/buffer_head.h>
 #include <linux/fs.h>
 #include <linux/list.h>
@@ -321,7 +322,7 @@ static inline int apfs_max_maps_per_block(struct super_block *sb)
 	unsigned long maps_size;
 
 	maps_size = (sb->s_blocksize - sizeof(struct apfs_checkpoint_map_phys));
-	return maps_size / sizeof(struct apfs_checkpoint_mapping);
+	return div_u64(maps_size, sizeof(struct apfs_checkpoint_mapping));
 }
 
 /*

--- a/object.c
+++ b/object.c
@@ -28,9 +28,9 @@ static u64 apfs_fletcher64(void *addr, size_t len)
 	}
 
 	c1 = sum1 + sum2;
-	c1 = 0xFFFFFFFF - do_div(c1, 0xFFFFFFFF);
+	c1 = 0xFFFFFFFF - div_u64(c1, 0xFFFFFFFF);
 	c2 = sum1 + c1;
-	c2 = 0xFFFFFFFF - do_div(c2, 0xFFFFFFFF);
+	c2 = 0xFFFFFFFF - div_u64(c2, 0xFFFFFFFF);
 
 	return (c2 << 32) | c1;
 }
@@ -170,8 +170,9 @@ static inline u32 apfs_index_in_data_area(struct super_block *sb, u64 bno)
 	u64 data_base = le64_to_cpu(raw_sb->nx_xp_data_base);
 	u32 data_index = le32_to_cpu(raw_sb->nx_xp_data_index);
 	u32 data_blks = le32_to_cpu(raw_sb->nx_xp_data_blocks);
-
-	return (bno - data_base + data_blks - data_index) % data_blks;
+	u32 remainder;
+	div_u64_rem(bno - data_base + data_blks - data_index, data_blks, &remainder);
+	return remainder;
 }
 
 /**

--- a/spaceman.c
+++ b/spaceman.c
@@ -3,6 +3,7 @@
  * Copyright (C) 2019 Ernesto A. Fernández <ernesto.mnd.fernandez@gmail.com>
  */
 
+#include <linux/math64.h>
 #include <linux/buffer_head.h>
 #include <linux/fs.h>
 #include "apfs.h"
@@ -969,7 +970,7 @@ static int apfs_main_free(struct super_block *sb, u64 bno)
 
 	if(!sm_raw->sm_blocks_per_chunk || !sm_raw->sm_chunks_per_cib)
 		return -EINVAL;
-	chunk_idx = bno / sm->sm_blocks_per_chunk;
+	chunk_idx = div_u64(bno, sm->sm_blocks_per_chunk);
 	cib_idx = chunk_idx / sm->sm_chunks_per_cib;
 	chunk_idx -= cib_idx * sm->sm_chunks_per_cib;
 

--- a/transaction.c
+++ b/transaction.c
@@ -278,7 +278,7 @@ int apfs_cpoint_data_free(struct super_block *sb, u64 bno)
 	 * We can't leave a hole in the data area, so we need to shift all
 	 * blocks that come after @bno one position back.
 	 */
-	bno_i = (bno - data_base + data_blks - data_index) % data_blks;
+	div_u64_rem(bno - data_base + data_blks - data_index, data_blks, &bno_i);
 	for (i = bno_i; i < data_len - 1; ++i) {
 		struct buffer_head *old_bh, *new_bh;
 		int err;


### PR DESCRIPTION
Otherwise on some architectures gcc emits calls to functions from -lgcc which is not available to the kernel.