### PR TITLE
Add support to kernel 7.0 fs new mount APIs (LP: #2142837)

### DIFF
--- a/apfs.h
+++ b/apfs.h
@@ -380,6 +380,9 @@ struct apfs_sb_info {
 	unsigned int s_vol_nr;		/* Index of the volume in the sb list */
 	kuid_t s_uid;			/* uid to override on-disk uid */
 	kgid_t s_gid;			/* gid to override on-disk gid */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	unsigned int s_mount_opt;
+#endif
 
 	struct apfs_crypto_state_val *s_dflt_pfk; /* default per-file key */
 

--- a/apfs.h
+++ b/apfs.h
@@ -1040,7 +1040,9 @@ extern int apfs_setattr(struct mnt_idmap *idmap,
 			struct dentry *dentry, struct iattr *iattr);
 #endif
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+extern int apfs_update_time(struct inode *inode, enum fs_update_time time, unsigned int flags);
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 extern int apfs_update_time(struct inode *inode, struct timespec64 *time, int flags);
 #else
 extern int apfs_update_time(struct inode *inode, int flags);

--- a/inode.c
+++ b/inode.c
@@ -2109,7 +2109,9 @@ fail:
 }
 
 /* TODO: this only seems to be necessary because ->write_inode() isn't firing */
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+int apfs_update_time(struct inode *inode, enum fs_update_time time, unsigned int flags)
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)
 int apfs_update_time(struct inode *inode, struct timespec64 *time, int flags)
 #else
 int apfs_update_time(struct inode *inode, int flags)
@@ -2123,7 +2125,7 @@ int apfs_update_time(struct inode *inode, int flags)
 		return err;
 	apfs_inode_join_transaction(sb, inode);
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && !RHEL_VERSION_GE(9, 6)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0) || LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)) && !RHEL_VERSION_GE(9, 6)
 	generic_update_time(inode, time, flags);
 #else
 	generic_update_time(inode, flags);

--- a/inode.c
+++ b/inode.c
@@ -2125,7 +2125,9 @@ int apfs_update_time(struct inode *inode, int flags)
 		return err;
 	apfs_inode_join_transaction(sb, inode);
 
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0) || LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0)) && !RHEL_VERSION_GE(9, 6)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	generic_update_time(inode, time, flags);
+#elif LINUX_VERSION_CODE < KERNEL_VERSION(6, 6, 0) && !RHEL_VERSION_GE(9, 6)
 	generic_update_time(inode, time, flags);
 #else
 	generic_update_time(inode, flags);

--- a/super.c
+++ b/super.c
@@ -1235,6 +1235,22 @@ static void apfs_set_nx_flags(struct super_block *sb, unsigned int flags)
 	mutex_unlock(&nxs_mutex);
 }
 
+void parse_options_set_flags(struct super_block *sb, struct apfs_sb_info *sbi,
+		unsigned int nx_flags)
+{
+	struct apfs_nxsb_info *nxi = sbi->s_nxi;
+	apfs_set_nx_flags(sb, nx_flags);
+	if (!(sb->s_flags & SB_RDONLY)) {
+		if (nxi->nx_flags & APFS_READWRITE) {
+			apfs_notice(sb, "experimental write support is enabled");
+		} else {
+			apfs_warn(sb, "experimental writes disabled to avoid data loss");
+			apfs_warn(sb, "if you really want them, check the README");
+			sb->s_flags |= SB_RDONLY;
+		}
+	}
+}
+
 /*
  * Many of the parse_options() functions in other file systems return 0
  * on error. This one returns an error code, and 0 on success.
@@ -1252,7 +1268,6 @@ static int parse_options(struct super_block *sb, char *options)
 	#define opt_alert_parse(fmt, ...) apfs_err(sb, fmt, ##__VA_ARGS__)
 	struct apfs_sb_info *sbi = APFS_SB(sb);
 #endif
-	struct apfs_nxsb_info *nxi = sbi->s_nxi;
 	char *p;
 	substring_t args[MAX_OPT_ARGS];
 	int option;
@@ -1335,16 +1350,7 @@ out:
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
 	sbi->s_mount_opt = nx_flags;
 #else
-	apfs_set_nx_flags(sb, nx_flags);
-	if (!(sb->s_flags & SB_RDONLY)) {
-		if (nxi->nx_flags & APFS_READWRITE) {
-			apfs_notice(sb, "experimental write support is enabled");
-		} else {
-			apfs_warn(sb, "experimental writes disabled to avoid data loss");
-			apfs_warn(sb, "if you really want them, check the README");
-			sb->s_flags |= SB_RDONLY;
-		}
-	}
+	parse_options_set_flags(sb, sbi, nx_flags);
 #endif
 	return 0;
 #undef opt_err_parse
@@ -1581,16 +1587,7 @@ static int apfs_fill_super(struct super_block *sb, void *data, int silent)
 		goto failed_volume;
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
-	apfs_set_nx_flags(sb, sbi->s_mount_opt);
-	if (!(sb->s_flags & SB_RDONLY)) {
-		if (sbi->s_mount_opt & APFS_READWRITE) {
-			apfs_notice(sb, "experimental write support is enabled");
-		} else {
-			apfs_warn(sb, "experimental writes disabled to avoid data loss");
-			apfs_warn(sb, "if you really want them, check the README");
-			sb->s_flags |= SB_RDONLY;
-		}
-	}
+	parse_options_set_flags(sb, sbi, sbi->s_mount_opt);
 #else
 	sbi->s_uid = INVALID_UID;
 	sbi->s_gid = INVALID_GID;

--- a/super.c
+++ b/super.c
@@ -462,15 +462,12 @@ static void apfs_blkdev_cleanup(struct apfs_blkdev_info *info)
  */
 static inline void apfs_free_main_super(struct apfs_sb_info *sbi)
 {
-	struct apfs_nxsb_info *nxi = NULL;
+	struct apfs_nxsb_info *nxi = sbi->s_nxi;
 	struct apfs_ephemeral_object_info *eph_list = NULL;
 	struct apfs_spaceman *sm = NULL;
 	u32 bmap_idx;
 	int i;
 
-	if (!sbi)
-		return;
-	nxi = sbi->s_nxi;
 	if (!nxi)
 		return;
 
@@ -1242,6 +1239,7 @@ void parse_options_set_flags(struct super_block *sb, struct apfs_sb_info *sbi,
 		unsigned int nx_flags)
 {
 	struct apfs_nxsb_info *nxi = sbi->s_nxi;
+
 	apfs_set_nx_flags(sb, nx_flags);
 	if (!(sb->s_flags & SB_RDONLY)) {
 		if (nxi->nx_flags & APFS_READWRITE) {
@@ -1261,14 +1259,10 @@ void parse_options_set_flags(struct super_block *sb, struct apfs_sb_info *sbi,
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
 static int parse_options(struct fs_context *fc, char *options)
 {
-	#define opt_err_parse(fmt, ...) apfs_err(NULL, fmt, ##__VA_ARGS__)
-	#define opt_alert_parse(fmt, ...) apfs_err(NULL, fmt, ##__VA_ARGS__)
     struct apfs_sb_info *sbi = fc->s_fs_info;
 #else
 static int parse_options(struct super_block *sb, char *options)
 {
-	#define opt_err_parse(fmt, ...) apfs_err(sb, fmt, ##__VA_ARGS__)
-	#define opt_alert_parse(fmt, ...) apfs_err(sb, fmt, ##__VA_ARGS__)
 	struct apfs_sb_info *sbi = APFS_SB(sb);
 #endif
 	char *p;
@@ -1320,7 +1314,7 @@ static int parse_options(struct super_block *sb, char *options)
 				return err;
 			sbi->s_uid = make_kuid(current_user_ns(), option);
 			if (!uid_valid(sbi->s_uid)) {
-				opt_err_parse("invalid uid");
+				apfs_err(NULL, "invalid uid");
 				return -EINVAL;
 			}
 			break;
@@ -1330,7 +1324,7 @@ static int parse_options(struct super_block *sb, char *options)
 				return err;
 			sbi->s_gid = make_kgid(current_user_ns(), option);
 			if (!gid_valid(sbi->s_gid)) {
-				opt_err_parse("invalid gid");
+				apfs_err(NULL, "invalid gid");
 				return -EINVAL;
 			}
 			break;
@@ -1344,7 +1338,7 @@ static int parse_options(struct super_block *sb, char *options)
 			 * We should have already checked the mount options in
 			 * apfs_preparse_options(), so this is a bug.
 			 */
-			opt_alert_parse("invalid mount option %s", p);
+			apfs_alert(NULL, "invalid mount option %s", p);
 			return -EINVAL;
 		}
 	}
@@ -1356,8 +1350,6 @@ out:
 	parse_options_set_flags(sb, sbi, nx_flags);
 #endif
 	return 0;
-#undef opt_err_parse
-#undef opt_alert_parse
 }
 
 /**
@@ -2220,11 +2212,12 @@ static void apfs_free_fc(struct fs_context *fc)
 
 static int apfs_parse_monolithic(struct fs_context *fc, void *data)
 {
-    struct apfs_sb_info *sbi = fc->s_fs_info;
-    int result = apfs_preparse_options(sbi, data);
-    if (result)
-        return result;
-    return parse_options(fc, data);
+	struct apfs_sb_info *sbi = fc->s_fs_info;
+	int result = apfs_preparse_options(sbi, data);
+
+	if (result)
+		return result;
+	return parse_options(fc, data);
 }
 
 static const struct fs_context_operations apfs_context_ops = {

--- a/super.c
+++ b/super.c
@@ -468,6 +468,9 @@ static inline void apfs_free_main_super(struct apfs_sb_info *sbi)
 	u32 bmap_idx;
 	int i;
 
+	if (!nxi || !sbi)
+		return;
+
 	mutex_lock(&nxs_mutex);
 
 	list_del(&sbi->list);

--- a/super.c
+++ b/super.c
@@ -2013,12 +2013,12 @@ static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 	sbi = kzalloc(sizeof(*sbi), GFP_KERNEL);
 	if (!sbi)
 		return ERR_PTR(-ENOMEM);
-#endif
 
 	/* Set up the fields that sget() will need to id the superblock */
 	error = apfs_preparse_options(sbi, data);
 	if (error)
 		goto out_free_sbi;
+#endif
 
 	/* Make sure that snapshots are mounted read-only */
 	if (sbi->s_snap_name)
@@ -2217,6 +2217,10 @@ static void apfs_free_fc(struct fs_context *fc)
 
 static int apfs_parse_monolithic(struct fs_context *fc, void *data)
 {
+    struct apfs_sb_info *sbi = fc->s_fs_info;
+    int result = apfs_preparse_options(sbi, data);
+    if (result)
+        return result;
     return parse_options(fc, data);
 }
 

--- a/super.c
+++ b/super.c
@@ -15,6 +15,9 @@
 #include <linux/seq_file.h>
 #include "apfs.h"
 #include "version.h"
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+#include <linux/fs_context.h>
+#endif
 
 #define APFS_MODULE_ID_STRING	"linux-apfs by eafer (" GIT_COMMIT ")"
 
@@ -1187,7 +1190,9 @@ static const struct super_operations apfs_sops = {
 	.put_super	= apfs_put_super,
 	.sync_fs	= apfs_sync_fs,
 	.statfs		= apfs_statfs,
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 	.remount_fs	= apfs_remount,
+#endif
 	.show_options	= apfs_show_options,
 };
 
@@ -1946,22 +1951,37 @@ out:
 /*
  * This function is a copy of mount_bdev() that allows multiple mounts.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+static int apfs_test_super_fc(struct super_block *sb, struct fs_context *fc);
+static int apfs_set_super_fc(struct super_block *sb, struct fs_context *fc);
+static int apfs_get_tree(struct fs_context *fc)
+#else
 static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 				 const char *dev_name, void *data)
+#endif
 {
 	struct super_block *sb;
 	struct apfs_sb_info *sbi;
 	struct apfs_blkdev_info *bd_info = NULL, *tier2_info = NULL;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || RHEL_VERSION_GE(9, 4)
+	int error = 0;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	blk_mode_t mode = sb_open_mode(fc->sb_flags);
+	void *data = fc->fs_private;
+	const char *dev_name = fc->source;
+	
+	sbi = fc->s_fs_info;
+#elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || RHEL_VERSION_GE(9, 4)
 	blk_mode_t mode = sb_open_mode(flags);
 #else
 	fmode_t mode = FMODE_READ | FMODE_EXCL;
 #endif
-	int error = 0;
 
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 	sbi = kzalloc(sizeof(*sbi), GFP_KERNEL);
 	if (!sbi)
 		return ERR_PTR(-ENOMEM);
+#endif
+
 	/* Set up the fields that sget() will need to id the superblock */
 	error = apfs_preparse_options(sbi, data);
 	if (error)
@@ -1969,7 +1989,11 @@ static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 
 	/* Make sure that snapshots are mounted read-only */
 	if (sbi->s_snap_name)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+		fc->sb_flags |= SB_RDONLY;
+#else
 		flags |= SB_RDONLY;
+#endif
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) && !RHEL_VERSION_GE(9, 4)
 	if (!(flags & SB_RDONLY))
@@ -1981,7 +2005,12 @@ static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 		goto out_free_sbi;
 
 	/* TODO: lockfs stuff? Btrfs doesn't seem to care */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	fc->sb_flags |= SB_NOSEC;
+	sb = sget_fc(fc, apfs_test_super_fc, apfs_set_super_fc);
+#else
 	sb = sget(fs_type, apfs_test_super, apfs_set_super, flags | SB_NOSEC, sbi);
+#endif
 	if (IS_ERR(sb)) {
 		error = PTR_ERR(sb);
 		goto out_unmap_super;
@@ -1997,7 +2026,11 @@ static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 	WARN_ON(sb->s_dev != bd_info->blki_bdev->bd_dev);
 
 	if (sb->s_root) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+		if ((fc->sb_flags ^ sb->s_flags) & SB_RDONLY) {
+#else
 		if ((flags ^ sb->s_flags) & SB_RDONLY) {
+#endif
 			error = -EBUSY;
 			deactivate_locked_super(sb);
 			goto out_unmap_super;
@@ -2009,8 +2042,14 @@ static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 		kfree(sbi->s_tier2_path);
 		sbi->s_tier2_path = NULL;
 		kfree(sbi);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+		fc->s_fs_info = NULL;
+#endif
 		sbi = NULL;
 	} else {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+		fc->s_fs_info = NULL;
+#endif
 		if (!sbi->s_snap_name && !tier2_info)
 			snprintf(sb->s_id, sizeof(sb->s_id), "%pg:%u", bd_info->blki_bdev, sbi->s_vol_nr);
 		else if (!tier2_info)
@@ -2022,28 +2061,49 @@ static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 		error = apfs_read_main_super(sb);
 		if (error) {
 			deactivate_locked_super(sb);
-			return ERR_PTR(error);
+			goto out_return_error;
 		}
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 5, 0) && !RHEL_VERSION_GE(9, 4)
 		sb->s_mode = mode;
 #endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+		error = apfs_fill_super(sb, data, fc->sb_flags & SB_SILENT ? 1 : 0);
+#else
 		error = apfs_fill_super(sb, data, flags & SB_SILENT ? 1 : 0);
+#endif
 		if (error) {
 			deactivate_locked_super(sb);
-			return ERR_PTR(error);
+			goto out_return_error;
 		}
 		sb->s_flags |= SB_ACTIVE;
 	}
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	fc->root = dget(sb->s_root);
+	return 0;
+#else
 	return dget(sb->s_root);
+#endif
 
 out_unmap_super:
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 	apfs_free_main_super(sbi);
+#endif
 out_free_sbi:
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	return error;
+#else
 	kfree(sbi->s_snap_name);
 	kfree(sbi->s_tier2_path);
 	kfree(sbi);
+#endif
+out_return_error:
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	return error;
+#else
 	return ERR_PTR(error);
+#endif
 }
 
 /**
@@ -2091,10 +2151,66 @@ static void apfs_kill_sb(struct super_block *sb)
 	apfs_free_sb_info(sb);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+static int apfs_test_super_fc(struct super_block *sb, struct fs_context *fc)
+{
+	return apfs_test_super(sb, fc->s_fs_info);
+}
+
+static int apfs_set_super_fc(struct super_block *sb, struct fs_context *fc)
+{
+	return apfs_set_super(sb, fc->s_fs_info);
+}
+
+static int apfs_reconfigure(struct fs_context *fc)
+{
+	struct super_block *sb = fc->root->d_sb;
+	int flags = fc->sb_flags;
+
+	return apfs_remount(sb, &flags, fc->fs_private);
+}
+
+static void apfs_free_fc(struct fs_context *fc)
+{
+	struct apfs_sb_info *sbi = fc->s_fs_info;
+
+	if (sbi) {
+		apfs_free_main_super(sbi);
+		kfree(sbi->s_snap_name);
+		kfree(sbi->s_tier2_path);
+		kfree(sbi);
+	}
+}
+
+static const struct fs_context_operations apfs_context_ops = {
+	.get_tree    = apfs_get_tree,
+	.reconfigure = apfs_reconfigure,
+	.free        = apfs_free_fc,
+};
+
+static int apfs_init_fs_context(struct fs_context *fc)
+{
+	struct apfs_sb_info *sbi;
+
+	/* Setup happens here now instead of the top of apfs_mount */
+	sbi = kzalloc(sizeof(*sbi), GFP_KERNEL);
+	if (!sbi)
+		return -ENOMEM;
+
+	fc->s_fs_info = sbi;
+	fc->ops = &apfs_context_ops;
+	return 0;
+}
+#endif /* LINUX_VERSION_CODE >= 7.0.0 */
+
 static struct file_system_type apfs_fs_type = {
 	.owner		= THIS_MODULE,
 	.name		= "apfs",
+#if LINUX_VERSION_CODE < KERNEL_VERSION(7, 0, 0)
 	.mount		= apfs_mount,
+#else
+	.init_fs_context = apfs_init_fs_context,
+#endif
 	.kill_sb	= apfs_kill_sb,
 	.fs_flags	= FS_REQUIRES_DEV,
 };

--- a/super.c
+++ b/super.c
@@ -462,13 +462,16 @@ static void apfs_blkdev_cleanup(struct apfs_blkdev_info *info)
  */
 static inline void apfs_free_main_super(struct apfs_sb_info *sbi)
 {
-	struct apfs_nxsb_info *nxi = sbi->s_nxi;
+	struct apfs_nxsb_info *nxi = NULL;
 	struct apfs_ephemeral_object_info *eph_list = NULL;
 	struct apfs_spaceman *sm = NULL;
 	u32 bmap_idx;
 	int i;
 
-	if (!nxi || !sbi)
+	if (!sbi)
+		return;
+	nxi = sbi->s_nxi;
+	if (!nxi)
 		return;
 
 	mutex_lock(&nxs_mutex);
@@ -2001,7 +2004,7 @@ static struct dentry *apfs_mount(struct file_system_type *fs_type, int flags,
 	blk_mode_t mode = sb_open_mode(fc->sb_flags);
 	void *data = fc->fs_private;
 	const char *dev_name = fc->source;
-	
+
 	sbi = fc->s_fs_info;
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || RHEL_VERSION_GE(9, 4)
 	blk_mode_t mode = sb_open_mode(flags);

--- a/super.c
+++ b/super.c
@@ -1239,9 +1239,19 @@ static void apfs_set_nx_flags(struct super_block *sb, unsigned int flags)
  * Many of the parse_options() functions in other file systems return 0
  * on error. This one returns an error code, and 0 on success.
  */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+static int parse_options(struct fs_context *fc, char *options)
+{
+	#define opt_err_parse(fmt, ...) apfs_err(NULL, fmt, ##__VA_ARGS__)
+	#define opt_alert_parse(fmt, ...) apfs_err(NULL, fmt, ##__VA_ARGS__)
+    struct apfs_sb_info *sbi = fc->s_fs_info;
+#else
 static int parse_options(struct super_block *sb, char *options)
 {
+	#define opt_err_parse(fmt, ...) apfs_err(sb, fmt, ##__VA_ARGS__)
+	#define opt_alert_parse(fmt, ...) apfs_err(sb, fmt, ##__VA_ARGS__)
 	struct apfs_sb_info *sbi = APFS_SB(sb);
+#endif
 	struct apfs_nxsb_info *nxi = sbi->s_nxi;
 	char *p;
 	substring_t args[MAX_OPT_ARGS];
@@ -1255,6 +1265,11 @@ static int parse_options(struct super_block *sb, char *options)
 #ifdef CONFIG_APFS_RW_ALWAYS
 	/* Still risky, but some packagers want writable mounts by default */
 	nx_flags |= APFS_READWRITE;
+#endif
+
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	sbi->s_uid = INVALID_UID;
+	sbi->s_gid = INVALID_GID;
 #endif
 
 	if (!options)
@@ -1287,7 +1302,7 @@ static int parse_options(struct super_block *sb, char *options)
 				return err;
 			sbi->s_uid = make_kuid(current_user_ns(), option);
 			if (!uid_valid(sbi->s_uid)) {
-				apfs_err(sb, "invalid uid");
+				opt_err_parse("invalid uid");
 				return -EINVAL;
 			}
 			break;
@@ -1297,7 +1312,7 @@ static int parse_options(struct super_block *sb, char *options)
 				return err;
 			sbi->s_gid = make_kgid(current_user_ns(), option);
 			if (!gid_valid(sbi->s_gid)) {
-				apfs_err(sb, "invalid gid");
+				opt_err_parse("invalid gid");
 				return -EINVAL;
 			}
 			break;
@@ -1311,12 +1326,15 @@ static int parse_options(struct super_block *sb, char *options)
 			 * We should have already checked the mount options in
 			 * apfs_preparse_options(), so this is a bug.
 			 */
-			apfs_alert(sb, "invalid mount option %s", p);
+			opt_alert_parse("invalid mount option %s", p);
 			return -EINVAL;
 		}
 	}
 
 out:
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	sbi->s_mount_opt = nx_flags;
+#else
 	apfs_set_nx_flags(sb, nx_flags);
 	if (!(sb->s_flags & SB_RDONLY)) {
 		if (nxi->nx_flags & APFS_READWRITE) {
@@ -1327,7 +1345,10 @@ out:
 			sb->s_flags |= SB_RDONLY;
 		}
 	}
+#endif
 	return 0;
+#undef opt_err_parse
+#undef opt_alert_parse
 }
 
 /**
@@ -1559,12 +1580,24 @@ static int apfs_fill_super(struct super_block *sb, void *data, int silent)
 	if (err)
 		goto failed_volume;
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 0, 0)
+	apfs_set_nx_flags(sb, sbi->s_mount_opt);
+	if (!(sb->s_flags & SB_RDONLY)) {
+		if (sbi->s_mount_opt & APFS_READWRITE) {
+			apfs_notice(sb, "experimental write support is enabled");
+		} else {
+			apfs_warn(sb, "experimental writes disabled to avoid data loss");
+			apfs_warn(sb, "if you really want them, check the README");
+			sb->s_flags |= SB_RDONLY;
+		}
+	}
+#else
 	sbi->s_uid = INVALID_UID;
 	sbi->s_gid = INVALID_GID;
 	err = parse_options(sb, data);
 	if (err)
 		goto failed_volume;
-
+#endif
 	err = apfs_map_volume_super(sb, false /* write */);
 	if (err)
 		goto failed_volume;
@@ -2185,10 +2218,16 @@ static void apfs_free_fc(struct fs_context *fc)
 	}
 }
 
+static int apfs_parse_monolithic(struct fs_context *fc, void *data)
+{
+    return parse_options(fc, data);
+}
+
 static const struct fs_context_operations apfs_context_ops = {
 	.get_tree    = apfs_get_tree,
 	.reconfigure = apfs_reconfigure,
 	.free        = apfs_free_fc,
+	.parse_monolithic = apfs_parse_monolithic,
 };
 
 static int apfs_init_fs_context(struct fs_context *fc)

--- a/super.c
+++ b/super.c
@@ -1235,7 +1235,7 @@ static void apfs_set_nx_flags(struct super_block *sb, unsigned int flags)
 	mutex_unlock(&nxs_mutex);
 }
 
-void parse_options_set_flags(struct super_block *sb, struct apfs_sb_info *sbi,
+static void parse_options_set_flags(struct super_block *sb, struct apfs_sb_info *sbi,
 		unsigned int nx_flags)
 {
 	struct apfs_nxsb_info *nxi = sbi->s_nxi;


### PR DESCRIPTION
As all the in-tree modules has been ported to the new Kernel 7 fs mount API, the old API has been removed.

This patch add the support for the new set of APIs, while keeping previous kernel support intact.

The code is in review on the Canonical Launchpad bug https://launchpad.net/bugs/2142837 as well.

The code has been compile-tested for the following kernels:
```
linux-apfs-rw/0.3.18, 6.8.0-100-generic, x86_64: installed
linux-apfs-rw/0.3.18, 6.14.0-37-generic, x86_64: installed
linux-apfs-rw/0.3.18, 6.17.0-14-generic, x86_64: installed
linux-apfs-rw/0.3.18, 6.19.0-6-generic, x86_64: installed
linux-apfs-rw/0.3.18, 7.0.0-1-generic, x86_64: installed
```