### PR TITLE
Rename $(CONFIG) to $(APFS_CONFIG)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,9 @@ apfs-y := btree.o compress.o dir.o extents.o file.o inode.o key.o libzbitmap.o \
 	  spaceman.o super.o symlink.o transaction.o unicode.o xattr.o xfield.o
 
 # If you want mounts to be writable by default, run the build as:
-#   make CONFIG=-DCONFIG_APFS_RW_ALWAYS
+#   make APFS_CONFIG=-DCONFIG_APFS_RW_ALWAYS
 # This is risky and not generally recommended.
-ccflags-y += $(CONFIG)
+ccflags-y += $(APFS_CONFIG)
 
 default:
 	./genver.sh


### PR DESCRIPTION
I was creating a custom Ubuntu ISO with this shipped as a DKMS package, but everytime it failed to compile. It turned out that the Ubuntu install created CONFIG as an environment variable, thus breaking build. So, rename the variable in the Makefile to something unique so that such incidences don't occur.

Logs of the failed build:

```
DKMS (dkms-3.2.0) make.log for linux-apfs-rw/0.1 for kernel 6.17.0-5-generic (x86_64)
Wed Mar 11 19:00:55 UTC 2026

Running the pre_build script
# command: cd /var/lib/dkms/linux-apfs-rw/0.1/build/ && /var/lib/dkms/linux-apfs-rw/0.1/build/genver.sh

# exit code: 0
# elapsed time: 00:00:00
----------------------------------------------------------------

Building module(s)
# command: make -j12 KERNELRELEASE=6.17.0-5-generic -C /lib/modules/6.17.0-5-generic/build M=/var/lib/dkms/linux-apfs-rw/0.1/build
make: Entering directory '/usr/src/linux-headers-6.17.0-5-generic'
make[1]: Entering directory '/var/lib/dkms/linux-apfs-rw/0.1/build'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: x86_64-linux-gnu-gcc (Ubuntu 15.2.0-4ubuntu2) 15.2.0
  You are using:           gcc (Ubuntu 15.2.0-4ubuntu4) 15.2.0
  CC [M]  btree.o
  CC [M]  compress.o
  CC [M]  dir.o
  CC [M]  extents.o
  CC [M]  file.o
  CC [M]  inode.o
  CC [M]  key.o
  CC [M]  libzbitmap.o
  CC [M]  lzfse/lzfse_decode.o
  CC [M]  lzfse/lzfse_decode_base.o
  CC [M]  lzfse/lzfse_fse.o
  CC [M]  lzfse/lzvn_decode_base.o
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: libzbitmap.o] Error 1
make[3]: *** Deleting file 'libzbitmap.o'
make[3]: *** Waiting for unfinished jobs....
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: lzfse/lzfse_fse.o] Error 1
make[3]: *** Deleting file 'lzfse/lzfse_fse.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: lzfse/lzvn_decode_base.o] Error 1
make[3]: *** Deleting file 'lzfse/lzvn_decode_base.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: lzfse/lzfse_decode.o] Error 1
make[3]: *** Deleting file 'lzfse/lzfse_decode.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: lzfse/lzfse_decode_base.o] Error 1
make[3]: *** Deleting file 'lzfse/lzfse_decode_base.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: key.o] Error 1
make[3]: *** Deleting file 'key.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: compress.o] Error 1
make[3]: *** Deleting file 'compress.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: file.o] Error 1
make[3]: *** Deleting file 'file.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: btree.o] Error 1
make[3]: *** Deleting file 'btree.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: dir.o] Error 1
make[3]: *** Deleting file 'dir.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: extents.o] Error 1
make[3]: *** Deleting file 'extents.o'
gcc: warning: /tmp/tmpjsn3t8mb/state/config: linker input file unused because linking not done
gcc: error: /tmp/tmpjsn3t8mb/state/config: linker input file not found: No such file or directory
make[3]: *** [/usr/src/linux-headers-6.17.0-5-generic/scripts/Makefile.build:287: inode.o] Error 1
make[3]: *** Deleting file 'inode.o'
make[2]: *** [/usr/src/linux-headers-6.17.0-5-generic/Makefile:2016: .] Error 2
make[1]: *** [/usr/src/linux-headers-6.17.0-5-generic/Makefile:248: __sub-make] Error 2
make[1]: Leaving directory '/var/lib/dkms/linux-apfs-rw/0.1/build'
make: *** [Makefile:248: __sub-make] Error 2
make: Leaving directory '/usr/src/linux-headers-6.17.0-5-generic'

# exit code: 2
# elapsed time: 00:00:05
----------------------------------------------------------------
```